### PR TITLE
Add ability to define custom presets

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -4,14 +4,13 @@
 
 const {execSync} = require('child_process');
 const path = require('path');
-const {size, map, omit} = require('lodash');
-const chalk = require('chalk');
+const {map, omit} = require('lodash');
 const pkg = require('../package.json');
 const yargs = require('yargs');
 
 const envCwd = `--env.cwd=${process.cwd()}`;
-const envArgs = map(omit(yargs.argv, ['_', '$0']), (val, arg) => `--env.${arg}=${val}`).join(' ');
-const nodeEnv = env => `NODE_ENV=${yargs.argv.env || env}`;
+const envArgs = map(omit(yargs.argv, ['_', '$0', 'env']), (val, arg) => `--env.${arg}=${val}`).join(' ');
+const nodeEnv = env => `NODE_ENV=${yargs.argv.environment || env}`;
 
 if(yargs.argv._ && yargs.argv._.length) {
   const cmds = {

--- a/loaders/index.js
+++ b/loaders/index.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const {flatMap} = require('lodash');
+const path = require('path');
 
 module.exports = config => {
   const additionalPresets = flatMap(config.dotFile.presets || [], preset =>
-    require(`./${preset}`)(config)
+    require(preset[0] === '.' ? path.resolve(config.cwd, preset) : `./${preset}`)(config)
   );
 
   const exludePatterns = additionalPresets.map(preset => preset.test);


### PR DESCRIPTION
We can now define custom presets by specifying a relative filepath in our `.webpacker.json`.

I renamed the `yargs.argv.environment` to `yargs.argv.env` to prevent node from passing an object into that environment when running webpacker as a child process.

Closes #1 