### PR TITLE
Config can now be generated by js

### DIFF
--- a/configHelpers.js
+++ b/configHelpers.js
@@ -46,7 +46,9 @@ const resolveConfig = argv => {
   return {
     ...config,
     dotFile: Object.assign({},
-      resolveDotFile(config.cwd) || {modules: [`${config.cwd}/node_modules`]},
+      !config.skipDotFile
+        ? resolveDotFile(config.cwd) || {modules: [`${config.cwd}/node_modules`]}
+        : {},
       pick(
         config,
         ['index', 'entry', 'app', 'config', 'output', 'scss', 'presets', 'customVariables']

--- a/createConfig.js
+++ b/createConfig.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/* eslint-disable no-console */
+const chalk = require('chalk');
+const path = require('path');
+const {stats, resolvePlugins, resolveConfig} = require('./configHelpers');
+const loaders = require('./loaders');
+
+module.exports = argv => {
+  const config = resolveConfig(argv);
+  const plugins = resolvePlugins(config);
+
+  if(config.logStd !== false) {
+    console.log(chalk.white.bgBlack(`Building for ${chalk.bold(config.env)} environment`), '\n');
+  }
+
+  const entry = {
+    app: [path.join(config.cwd, (config.dotFile.entry || 'src/index.js'))],
+  };
+
+  return {
+    bail: config.env === 'production',
+    devtool: (config.devServer || config.sourcemap) && 'sourcemap',
+    entry,
+    output: {
+      filename: `[name].bundle.js`,
+      publicPath: '/',
+      path: config.dotFile.output
+        ? path.isAbsolute(config.dotFile.output)
+          ? config.dotFile.output
+          : path.join(config.cwd, (config.dotFile.output || 'build'))
+        : undefined
+    },
+    devServer: {
+      contentBase: config.cwd,
+      compress: true,
+      historyApiFallback: true,
+      publicPath: '/',
+      host: '0.0.0.0',
+      disableHostCheck: true,
+      port: 4000,
+      stats,
+    },
+    stats,
+    plugins,
+    module: {
+      rules: loaders(config),
+    },
+    resolve: {
+      modules: config.dotFile.modules
+    }
+  };
+};

--- a/index.js
+++ b/index.js
@@ -1,49 +1,10 @@
 'use strict';
 
-/* eslint-disable no-console */
-const chalk = require('chalk');
-const path = require('path');
-const {stats, resolvePlugins, resolveConfig} = require('./configHelpers');
-const loaders = require('./loaders');
+const createConfig = require('./createConfig');
 
-module.exports = argv => {
-  const config = resolveConfig(argv);
-  const plugins = resolvePlugins(config);
-
-  console.log(chalk.white.bgBlack(`Building for ${chalk.bold(config.env)} environment`), '\n');
-
-  const entry = {
-    app: [path.join(config.cwd, (config.dotFile.entry || 'src/index.js'))],
-  };
-
-  return {
-    bail: config.env === 'production',
-    devtool: (config.devServer || config.sourcemap) && 'sourcemap',
-    entry,
-    output: {
-      filename: `[name].bundle.js`,
-      publicPath: '/',
-      path: path.isAbsolute(config.dotFile.output)
-        ? config.dotFile.output
-        : path.join(config.cwd, (config.dotFile.output || 'build'))
-    },
-    devServer: {
-      contentBase: config.cwd,
-      compress: true,
-      historyApiFallback: true,
-      publicPath: '/',
-      host: '0.0.0.0',
-      disableHostCheck: true,
-      port: 4000,
-      stats,
-    },
-    stats,
-    plugins,
-    module: {
-      rules: loaders(config),
-    },
-    resolve: {
-      modules: config.dotFile.modules
-    }
-  };
+const defaults = {
+  logStd: false,
+  skipDotFile: true
 };
+
+module.exports = argv => createConfig(Object.assign({}, defaults, argv));

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "webpacker": "./bin/index.js"
   },
   "scripts": {
-    "start": "webpack-dev-server --config ./index.js --env.devServer",
-    "build": "webpack --config ./index.js",
+    "start": "webpack-dev-server --config ./createConfig.js --env.devServer",
+    "build": "webpack --config ./createConfig.js",
     "webpacker": "webpacker",
     "release": "xyz --repo git@github.com:wearereasonablepeople/webpacker.git --increment"
   },


### PR DESCRIPTION
Webpacker can now be required and called with the same kind of config you would put in `.webpacker.json`.

Example:
```js
const createConfig = require('webpacker');
const webpack = require('webpack');

const config = createConfig({
  index: 'src/index.ejs',
  entry: 'src/index.js',
  app: 'src',
  config: 'config',
  output: 'dist',
  scss: 'src/scss',
  presets: ['react', 'scss'],
});
//config is just a webpack config object, so you can just modify/extend it if you want and pass it to webpack.
const compiler = webpack(config);
```

Closes #12 