### PR TITLE
Show compilation errors and warnings.

### DIFF
--- a/commands/serve.js
+++ b/commands/serve.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 const serve = require('webpack-serve');
+const chalk = require('chalk');
 
 const handler = (argv = {}) => {
   const {getConfig} = require('../getConfig');
@@ -9,13 +10,15 @@ const handler = (argv = {}) => {
   return serve(
     {
       ...args,
-      logLevel: 'silent',
+      logLevel: 'warn',
       clipboard: false,
     },
     {
       config,
       on: {
-        'build-started': () => console.log('\nBuild started...\n'),
+        'listening': ({options}) => console.log(
+          chalk.white.bgBlack(`Server running at ${chalk.bold(`http://${options.host}:${options.port}`)}`)
+        ),
         'build-finished': ({stats}) => console.log(stats.toString(config.stats)),
       },
     }


### PR DESCRIPTION
Currently compilation errors are not showing. Let's change that.
Also print dev server address instead 'build started'.
Information about default port is not exposed anywhere - this should fix it.