### PR TITLE
Prevent npm from generating package-lock

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Fixes #49 