### PR TITLE
Add devtool option to webpacker

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,10 @@ The following options can be adjusted by returning them as a key in `.webpacker.
 ### output
 `output` is for [webpack](https://webpack.js.org/concepts/#output)'s `output` option.
 
-## Example .webpacker.js
+### devtool
+`devtool` is for [webpack](https://webpack.js.org/configuration/devtool/)'s `devtool` option.
 
+### Example file
 ```js
 const path = require('path');
 const {setLoader, setPlugin} = require('webpacker/utils');

--- a/getConfig.js
+++ b/getConfig.js
@@ -75,6 +75,8 @@ const output = (out = {}) => ({
   filename: out.filename || '[name].bundle.js',
 });
 
+const devtool = (mode = 'eval') => mode;
+
 const checkFile = configFile => (key, fn) =>
   typeof configFile[key] === 'function' ? configFile[key](fn) : fn();
 
@@ -126,6 +128,7 @@ const getConfig = args => {
 
   return {
     ...baseConfig,
+    devtool: checkOption('devtool', devtool),
     serve: checkOption('serve', serve),
     resolve: checkOption('resolve', resolve),
     entry: checkOption('entry', entry),


### PR DESCRIPTION
Some people like to develop with SourceMaps available - let's make sure we give them this option.