### PR TITLE
Bumping version to 2.0.0 to use in webpacker npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpacker",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Webpack configuration manager",
   "main": "webpacker.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpacker",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Webpack configuration manager",
   "main": "webpacker.js",
   "bin": {


### PR DESCRIPTION
Now we have access to npm package `webpacker` and the last major version of legacy package is 1.0.0. The NPM team recommended to change the major version in our first release.

