### PR TITLE
fix: Don't use devtool on production environment by default

### DIFF
--- a/getConfig.js
+++ b/getConfig.js
@@ -76,7 +76,7 @@ const output = (out = {}) => ({
             process.env.NODE_ENV === 'production' ? '[name].[contenthash].js' : '[name].js',
 });
 
-const devtool = (mode = 'eval') => mode;
+const devtool = mode => mode || process.env.NODE_ENV === 'development' ? 'eval' : false;
 
 const checkFile = configFile => (key, fn) =>
   typeof configFile[key] === 'function' ? configFile[key](fn) : fn();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpacker",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Webpack configuration manager",
   "main": "webpacker.js",
   "bin": {


### PR DESCRIPTION
# Motivation
Fixes #70 

# Changes
- `getConfig` by default now only uses `'eval'` for development environment