### PR TITLE
Pass additional options to "output"

### DIFF
--- a/getConfig.js
+++ b/getConfig.js
@@ -71,6 +71,7 @@ const optimization = op => op || optimizations();
 
 const defaultPath = path.resolve(process.cwd(), 'dist');
 const output = (out = {}) => ({
+  ...out,
   path: out.path || defaultPath,
   filename: out.filename ||
             process.env.NODE_ENV === 'production' ? '[name].[contenthash].js' : '[name].js',


### PR DESCRIPTION
Documentation states that you can
`output is for webpack's output option.` - which is not true

I need to pass additional option to it but in reality It only accepts `{path, filename}`
```
output: fn => fn({
    path: path.join(__dirname, '/dist'),
    globalObject: "this"
}),
```