### PR TITLE
Feat: Pass additional options via "output"

### DIFF
--- a/getConfig.js
+++ b/getConfig.js
@@ -71,6 +71,7 @@ const optimization = op => op || optimizations();
 
 const defaultPath = path.resolve(process.cwd(), 'dist');
 const output = (out = {}) => ({
+  ...out,
   path: out.path || defaultPath,
   filename: out.filename ||
             process.env.NODE_ENV === 'production' ? '[name].[contenthash].js' : '[name].js',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpacker",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Webpack configuration manager",
   "main": "webpacker.js",
   "bin": {


### PR DESCRIPTION
# Motivation
Currently you can pass only `{path, filename}` to `output`
Allow to pass any `output` options for webapack https://webpack.js.org/concepts/#output

## Changes
Output will allow to pass any additional options like, for example
```
output: fn => fn({
    path: path.join(__dirname, '/dist'),
    globalObject: 'this'
}),
```