### PR TITLE
Allow to override optimization options

### DIFF
--- a/getConfig.js
+++ b/getConfig.js
@@ -67,7 +67,7 @@ const resolve = () => ({
 
 const entry = (ent = './src/index.js', cwd = process.cwd()) => path.resolve(cwd, ent);
 
-const optimization = op => op || optimizations();
+const optimization = op => optimizations(op);
 
 const defaultPath = path.resolve(process.cwd(), 'dist');
 const output = (out = {}) => ({

--- a/optimizations/index.js
+++ b/optimizations/index.js
@@ -1,7 +1,19 @@
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 
-module.exports = () => ({
+module.exports = ({
+  runtimeChunk = 'single',
+  splitChunks = {
+    chunks: 'all',
+    cacheGroups: {
+      commons: {
+        test: /[\\/]node_modules[\\/]/,
+        name: 'vendors',
+        chunks: 'all'
+      }
+    }
+  }
+} = {}) => ({
   minimizer: [
     new UglifyJsPlugin({
       sourceMap: false,
@@ -14,15 +26,6 @@ module.exports = () => ({
     }),
     new OptimizeCSSAssetsPlugin({})
   ],
-  runtimeChunk: 'single',
-  splitChunks: {
-    chunks: 'all',
-    cacheGroups: {
-      commons: {
-        test: /[\\/]node_modules[\\/]/,
-        name: 'vendors',
-        chunks: 'all'
-      }
-    }
-  }
+  runtimeChunk,
+  splitChunks,
 });


### PR DESCRIPTION
# Motivation
Currently option for runtimeChunk and splitChunks is hardcoded. 
Allow to pass it as other options. Should allow for any 

https://webpack.js.org/configuration/optimization/#optimization-runtimechunk
https://webpack.js.org/configuration/optimization/#optimization-splitchunks

`optimization: fn => fn({runtimeChunk: false})`

# Changes
```
- allow to pass {runtimeChunk} - defaults to 'single'
- allow to pass {splitChunks} - default to {
    chunks: 'all',
    cacheGroups: {
      commons: {
        test: /[\\/]node_modules[\\/]/,
        name: 'vendors',
        chunks: 'all'
      }
    }
  }
```

## TODO
Support more optimization options