### PR TITLE
Feat: Allow treshold option for compression

### DIFF
--- a/plugins/compress.js
+++ b/plugins/compress.js
@@ -1,7 +1,7 @@
 const CompressionPlugin = require('compression-webpack-plugin');
 
-module.exports = ({devServer}) => !devServer ? new CompressionPlugin({
-  test: /\.js$|\.css$|\.html$/,
-  threshold: 1024 * 10
+module.exports = ({devServer, threshold = 0}) => !devServer ? new CompressionPlugin({
+  test: /\.js$|\.css$|\.svg$|\.json$|\.html$/,
+  threshold
 }) : null;
 

--- a/tests/plugins/compress.test.js
+++ b/tests/plugins/compress.test.js
@@ -3,8 +3,8 @@ const compress = require('../../plugins/compress');
 describe('Compression plugin', () => {
   const defaults = {
     options: {
-      test: /\.js$|\.css$|\.html$/,
-      threshold: 1024 * 10
+      test: /\.js$|\.css$|\.svg$|\.json$|\.html$/,
+      threshold: 0
     },
   };
 


### PR DESCRIPTION
## Motivation
Currently default `threshold` for compression is rather height  (1024 * 10). Also there is no way to configure it.

## Changes
- Allow `threshold` in compression plugin.
- add `svg` & `json` to gziped assets since text zips nicely
- Defaults to `threshold = 0`

Allows to 
`setPlugin('compress', {threshold: 1024}),`