### PR TITLE
Feat: allow mocking Node.js core library

### DIFF
--- a/getConfig.js
+++ b/getConfig.js
@@ -75,6 +75,8 @@ const resolve = r => ({
 
 const devtool = mode => mode || process.env.NODE_ENV === 'development' ? 'eval' : false;
 
+const node = node => node || {};
+
 const checkFile = configFile => (key, fn) =>
   typeof configFile[key] === 'function' ? configFile[key](fn) : fn();
 
@@ -126,6 +128,7 @@ const getConfig = args => {
 
   return {
     ...baseConfig,
+    node: checkOption('node', node),
     devtool: checkOption('devtool', devtool),
     devServer: checkOption('devServer', devServer),
     entry: checkOption('entry', entry),


### PR DESCRIPTION
# Motivation
Some libraries created primarily for Node.js env can run in browser. Webpack can "browserify" those
Option in webpack (https://webpack.js.org/configuration/node) that allows to mock / polyfill specific node core apis - like `fs` for example

# Changes
Allows `node` option in `.webpacker` config

Additional option - for example
```javascript
node: () => ({
    fs: 'empty'
}),
```