### PR TITLE
Replace uglifyJs with terser

### DIFF
--- a/optimizations/index.js
+++ b/optimizations/index.js
@@ -1,4 +1,4 @@
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 
 module.exports = ({
@@ -15,14 +15,8 @@ module.exports = ({
   }
 } = {}) => ({
   minimizer: [
-    new UglifyJsPlugin({
-      sourceMap: false,
-      parallel: true,
-      uglifyOptions: {
-        compress: {
-          inline: false
-        }
-      }
+    new TerserPlugin({
+      parallel: true
     }),
     new OptimizeCSSAssetsPlugin({})
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpacker",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Webpack configuration manager",
   "main": "webpacker.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "postcss-will-change-transition": "^1.2.0",
     "sass-loader": "^7.1.0",
     "style-loader": "^0.23.1",
-    "uglifyjs-webpack-plugin": "^2.1.1",
+    "terser-webpack-plugin": "^1.2.3",
     "url-loader": "^1.1.2",
     "webapp-webpack-plugin": "^2.3.1",
     "webpack": "^4.20.2",


### PR DESCRIPTION
Current version of react cannot be minified with UglifyJs. It's know issue for React team.
Terser is suggested by React team as a minifier for ES6 code.

Some sources:
https://github.com/rails/webpacker/issues/1719
https://twitter.com/dan_abramov/status/1060245441084825600