### PR TITLE
feat: Add include option. Remove default exclude

### DIFF
--- a/loaders/css.js
+++ b/loaders/css.js
@@ -1,8 +1,9 @@
 const {extractCssPlugin, postcss} = require('./utils');
 
-module.exports = ({env, postcssOpts, exclude = /node_modules/}) => ({
+module.exports = ({env, postcssOpts, exclude, include}) => ({
   test: /\.css$/,
   exclude,
+  include,
   loader: extractCssPlugin(env)([
     {
       loader: 'css-loader',

--- a/loaders/scss.js
+++ b/loaders/scss.js
@@ -2,10 +2,11 @@ const {extractCssPlugin, postcss} = require('./utils');
 const {readFileSync} = require('fs');
 
 module.exports = (
-  {env, scssVariables, postcssOpts, exclude = /node_modules/}) => (
+  {env, scssVariables, postcssOpts, exclude, include}) => (
   {
     test: /\.scss$/,
     exclude,
+    include,
     loader: extractCssPlugin(env)([
       {
         loader: 'css-loader',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpacker",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Webpack configuration manager",
   "main": "webpacker.js",
   "bin": {


### PR DESCRIPTION
In order to accomodate for `include` options, the default `exclude` value should be undefined. The users of `webpacker` will have to set this option manually from now on.